### PR TITLE
Longer wall time for condor jobs

### DIFF
--- a/DeepNtuplizer/scripts/jobSub.py
+++ b/DeepNtuplizer/scripts/jobSub.py
@@ -205,7 +205,7 @@ def doSub():
         os.symlink(ntupleOutDir,jobpath+'/output')
 
 #The maximum wall time of a condor job is defined in the MaxRuntime parameter in seconds.
-# 3 hours (10800s) seems to be currently enough for any job
+# 3 hours (10800s) seems to be currently enough
 
         condorfile ="""executable            = {batchscriptpath}
 arguments             = {configfile} inputScript={sample} outputFile={ntupledir}{outputfile} nJobs={njobs} job=$(ProcId) {options}
@@ -215,7 +215,7 @@ log                   = batch/con_out.$(ProcId).log
 send_credential        = True
 getenv = True
 use_x509userproxy = True
-+MaxRuntime = 10800s
++MaxRuntime = 10800
 queue {njobs}
     """.format(
               batchscriptpath=sheelscp,
@@ -243,7 +243,7 @@ log   = batch/con_out.{job}.log
 send_credential = True
 getenv = True
 use_x509userproxy = True
-+MaxRuntime = 10800s
++MaxRuntime = 10800
 queue 1
              """.format(
                   batchscriptpath=sheelscp,

--- a/DeepNtuplizer/scripts/jobSub.py
+++ b/DeepNtuplizer/scripts/jobSub.py
@@ -79,10 +79,13 @@ def doSub():
         exit()
         
         
-    #make samples directory
+    #recreates samples directory (removing old one avoids pssible errors in creating importsamples)
     samplescriptdir=os.getenv('HOME')+'/.deepntuples_scripts_tmp'
     if not os.path.isdir(samplescriptdir):
         os.mkdir(samplescriptdir)
+    else:
+	shutil.rmtree(samplescriptdir)
+	os.mkdir(samplescriptdir)
     samplescriptdir+='/'
     
     #https://twiki.cern.ch/twiki/bin/view/CMSPublic/WorkBookStartingGrid

--- a/DeepNtuplizer/scripts/jobSub.py
+++ b/DeepNtuplizer/scripts/jobSub.py
@@ -203,7 +203,10 @@ def doSub():
         
         #link to ntupleOutDir
         os.symlink(ntupleOutDir,jobpath+'/output')
-           
+
+#The maximum wall time of a condor job is defined in the MaxRuntime parameter in seconds.
+# 3 hours (10800s) seems to be currently enough for any job
+
         condorfile ="""executable            = {batchscriptpath}
 arguments             = {configfile} inputScript={sample} outputFile={ntupledir}{outputfile} nJobs={njobs} job=$(ProcId) {options}
 output                = batch/con_out.$(ProcId).out
@@ -212,7 +215,7 @@ log                   = batch/con_out.$(ProcId).log
 send_credential        = True
 getenv = True
 use_x509userproxy = True
-+JobFlavour = "microcentury"
++MaxRuntime = 10800s
 queue {njobs}
     """.format(
               batchscriptpath=sheelscp,
@@ -240,7 +243,7 @@ log   = batch/con_out.{job}.log
 send_credential = True
 getenv = True
 use_x509userproxy = True
-+JobFlavour = "microcentury"
++MaxRuntime = 10800s
 queue 1
              """.format(
                   batchscriptpath=sheelscp,

--- a/DeepNtuplizer/scripts/jobSub.py
+++ b/DeepNtuplizer/scripts/jobSub.py
@@ -209,6 +209,7 @@ log                   = batch/con_out.$(ProcId).log
 send_credential        = True
 getenv = True
 use_x509userproxy = True
++JobFlavour = "microcentury"
 queue {njobs}
     """.format(
               batchscriptpath=sheelscp,
@@ -236,6 +237,7 @@ log   = batch/con_out.{job}.log
 send_credential = True
 getenv = True
 use_x509userproxy = True
++JobFlavour = "microcentury"
 queue 1
              """.format(
                   batchscriptpath=sheelscp,


### PR DESCRIPTION
Changed the wall time of condor jobs from 20 min to 3 hours which seems to be enough. This gets rid of the SYSTEM_PERIODIC_REMOVE problem killing off large number of jobs when the wall time runs out.