### PR TITLE
adding deepVertex Variables

### DIFF
--- a/DeepNtuplizer/interface/ntuple_DeepVertex.h
+++ b/DeepNtuplizer/interface/ntuple_DeepVertex.h
@@ -37,75 +37,78 @@ private:
     // seed candidates
     static constexpr size_t max_seeds=10;
     
-    int n_seeds=0;
+    unsigned int n_seeds=0;
+    float nSeeds=0;
     
-    double seed_pt[max_seeds];
-    double seed_eta[max_seeds];
-    double seed_phi[max_seeds];
-    double seed_mass[max_seeds];
+    float seed_pt[max_seeds];
+    float seed_eta[max_seeds];
+    float seed_phi[max_seeds];
+    float seed_mass[max_seeds];
 
-    double seed_dz[max_seeds];
-    double seed_dxy[max_seeds];
-    double seed_3D_ip[max_seeds];
-    double seed_3D_sip[max_seeds];
-    double seed_2D_ip[max_seeds];
-    double seed_2D_sip[max_seeds];
-    double seed_3D_signedIp[max_seeds];
-    double seed_3D_signedSip[max_seeds];
-    double seed_2D_signedIp[max_seeds];
-    double seed_2D_signedSip[max_seeds];
+    float seed_dz[max_seeds];
+    float seed_dxy[max_seeds];
+    float seed_3D_ip[max_seeds];
+    float seed_3D_sip[max_seeds];
+    float seed_2D_ip[max_seeds];
+    float seed_2D_sip[max_seeds];
+    float seed_3D_signedIp[max_seeds];
+    float seed_3D_signedSip[max_seeds];
+    float seed_2D_signedIp[max_seeds];
+    float seed_2D_signedSip[max_seeds];
     //int seed_JetMatch[max_seeds];
  
-    double seed_chi2reduced[max_seeds];
-    double seed_nPixelHits[max_seeds];
-    double seed_nHits[max_seeds];
-    double seed_jetAxisDistance[max_seeds];
-    double seed_jetAxisDlength[max_seeds];
+    float seed_chi2reduced[max_seeds];
+    float seed_nPixelHits[max_seeds];
+    float seed_nHits[max_seeds];
+    float seed_jetAxisDistance[max_seeds];
+    float seed_jetAxisDlength[max_seeds];
     
-    int seed_nNearTracks[max_seeds];
+    unsigned int seed_n_NearTracks[max_seeds];
+    float seed_nNearTracks[max_seeds];
     
     
     //nearest track candidates
     static constexpr size_t max_nearestTrk=200; // 20 per seed
     
-    int n_NearTracksTotal=0;
+    unsigned int n_NearTracksTotal=0;
+    float nNearTracksTotal=0;
     
-    double nearTracks_pt[max_nearestTrk];
-    double nearTracks_eta[max_nearestTrk];
-    double nearTracks_phi[max_nearestTrk];
-    double nearTracks_mass[max_nearestTrk];
-    double nearTracks_dz[max_nearestTrk];
-    double nearTracks_dxy[max_nearestTrk];
-    double nearTracks_3D_ip[max_nearestTrk];
-    double nearTracks_3D_sip[max_nearestTrk];
-    double nearTracks_2D_ip[max_nearestTrk];
-    double nearTracks_2D_sip[max_nearestTrk];
-    double nearTracks_PCAdist[max_nearestTrk];
-    double nearTracks_PCAdsig[max_nearestTrk];      
-    double nearTracks_PCAonSeed_x[max_nearestTrk];
-    double nearTracks_PCAonSeed_y[max_nearestTrk];
-    double nearTracks_PCAonSeed_z[max_nearestTrk];      
-    double nearTracks_PCAonSeed_xerr[max_nearestTrk];
-    double nearTracks_PCAonSeed_yerr[max_nearestTrk];
-    double nearTracks_PCAonSeed_zerr[max_nearestTrk];      
-    double nearTracks_PCAonTrack_x[max_nearestTrk];
-    double nearTracks_PCAonTrack_y[max_nearestTrk];
-    double nearTracks_PCAonTrack_z[max_nearestTrk];      
-    double nearTracks_PCAonTrack_xerr[max_nearestTrk];
-    double nearTracks_PCAonTrack_yerr[max_nearestTrk];
-    double nearTracks_PCAonTrack_zerr[max_nearestTrk]; 
-    double nearTracks_dotprodTrack[max_nearestTrk];
-    double nearTracks_dotprodSeed[max_nearestTrk];
-    double nearTracks_dotprodTrackSeed2D[max_nearestTrk];
-    double nearTracks_dotprodTrackSeed3D[max_nearestTrk];
-    double nearTracks_dotprodTrackSeedVectors2D[max_nearestTrk];
-    double nearTracks_dotprodTrackSeedVectors3D[max_nearestTrk];      
-    double nearTracks_PCAonSeed_pvd[max_nearestTrk];
-    double nearTracks_PCAonTrack_pvd[max_nearestTrk];
-    double nearTracks_PCAjetAxis_dist[max_nearestTrk];
-    double nearTracks_PCAjetMomenta_dotprod[max_nearestTrk];
-    double nearTracks_PCAjetDirs_DEta[max_nearestTrk];
-    double nearTracks_PCAjetDirs_DPhi[max_nearestTrk];
+    float nearTracks_pt[max_nearestTrk];
+    float nearTracks_eta[max_nearestTrk];
+    float nearTracks_phi[max_nearestTrk];
+    float nearTracks_mass[max_nearestTrk];
+    float nearTracks_dz[max_nearestTrk];
+    float nearTracks_dxy[max_nearestTrk];
+    float nearTracks_3D_ip[max_nearestTrk];
+    float nearTracks_3D_sip[max_nearestTrk];
+    float nearTracks_2D_ip[max_nearestTrk];
+    float nearTracks_2D_sip[max_nearestTrk];
+    float nearTracks_PCAdist[max_nearestTrk];
+    float nearTracks_PCAdsig[max_nearestTrk];      
+    float nearTracks_PCAonSeed_x[max_nearestTrk];
+    float nearTracks_PCAonSeed_y[max_nearestTrk];
+    float nearTracks_PCAonSeed_z[max_nearestTrk];      
+    float nearTracks_PCAonSeed_xerr[max_nearestTrk];
+    float nearTracks_PCAonSeed_yerr[max_nearestTrk];
+    float nearTracks_PCAonSeed_zerr[max_nearestTrk];      
+    float nearTracks_PCAonTrack_x[max_nearestTrk];
+    float nearTracks_PCAonTrack_y[max_nearestTrk];
+    float nearTracks_PCAonTrack_z[max_nearestTrk];      
+    float nearTracks_PCAonTrack_xerr[max_nearestTrk];
+    float nearTracks_PCAonTrack_yerr[max_nearestTrk];
+    float nearTracks_PCAonTrack_zerr[max_nearestTrk]; 
+    float nearTracks_dotprodTrack[max_nearestTrk];
+    float nearTracks_dotprodSeed[max_nearestTrk];
+    float nearTracks_dotprodTrackSeed2D[max_nearestTrk];
+    float nearTracks_dotprodTrackSeed3D[max_nearestTrk];
+    float nearTracks_dotprodTrackSeedVectors2D[max_nearestTrk];
+    float nearTracks_dotprodTrackSeedVectors3D[max_nearestTrk];      
+    float nearTracks_PCAonSeed_pvd[max_nearestTrk];
+    float nearTracks_PCAonTrack_pvd[max_nearestTrk];
+    float nearTracks_PCAjetAxis_dist[max_nearestTrk];
+    float nearTracks_PCAjetMomenta_dotprod[max_nearestTrk];
+    float nearTracks_PCAjetDirs_DEta[max_nearestTrk];
+    float nearTracks_PCAjetDirs_DPhi[max_nearestTrk];
     
     
     // IVF cut parameters (HARDCODED?? OR CONFIGURABLE IN PYTHON CONFIG)

--- a/DeepNtuplizer/interface/ntuple_DeepVertex.h
+++ b/DeepNtuplizer/interface/ntuple_DeepVertex.h
@@ -1,0 +1,137 @@
+/*
+ * ntuple_DeepVertex.h
+ *
+ *  Created on: 23 June 2017
+ *      Author: Seth Moortgat
+ */
+
+#ifndef DEEPNTUPLES_DEEPNTUPLIZER_INTERFACE_NTUPLE_DEEPVERTEX_H_
+#define DEEPNTUPLES_DEEPNTUPLIZER_INTERFACE_NTUPLE_DEEPVERTEX_H_
+
+#include "ntuple_content.h"
+#include "trackVars2.h"
+#include "TrackingTools/TransientTrack/interface/TransientTrackBuilder.h"
+
+class ntuple_DeepVertex: public ntuple_content{
+public:
+
+    ntuple_DeepVertex(double jetR = 0.4);
+    ~ntuple_DeepVertex();
+
+    void getInput(const edm::ParameterSet& iConfig);
+    void initBranches(TTree* );
+    void readEvent(const edm::Event& iEvent);
+    void readSetup(const edm::EventSetup& iSetup);
+
+    //use either of these functions
+
+    bool fillBranches(const pat::Jet &, const size_t& jetidx, const  edm::View<pat::Jet> * coll=0);
+
+
+    void setCandidatesToken(const edm::EDGetTokenT<edm::View<pat::PackedCandidate> > & t){
+        CandidateToken=t;
+     }
+
+private:
+
+    // seed candidates
+    static constexpr size_t max_seeds=10;
+    
+    int n_seeds=0;
+    
+    double seed_pt[max_seeds];
+    double seed_eta[max_seeds];
+    double seed_phi[max_seeds];
+    double seed_mass[max_seeds];
+
+    double seed_dz[max_seeds];
+    double seed_dxy[max_seeds];
+    double seed_3D_ip[max_seeds];
+    double seed_3D_sip[max_seeds];
+    double seed_2D_ip[max_seeds];
+    double seed_2D_sip[max_seeds];
+    double seed_3D_signedIp[max_seeds];
+    double seed_3D_signedSip[max_seeds];
+    double seed_2D_signedIp[max_seeds];
+    double seed_2D_signedSip[max_seeds];
+    //int seed_JetMatch[max_seeds];
+ 
+    double seed_chi2reduced[max_seeds];
+    double seed_nPixelHits[max_seeds];
+    double seed_nHits[max_seeds];
+    double seed_jetAxisDistance[max_seeds];
+    double seed_jetAxisDlength[max_seeds];
+    
+    int seed_nNearTracks[max_seeds];
+    
+    
+    //nearest track candidates
+    static constexpr size_t max_nearestTrk=200; // 20 per seed
+    
+    int n_NearTracksTotal=0;
+    
+    double nearTracks_pt[max_nearestTrk];
+    double nearTracks_eta[max_nearestTrk];
+    double nearTracks_phi[max_nearestTrk];
+    double nearTracks_mass[max_nearestTrk];
+    double nearTracks_dz[max_nearestTrk];
+    double nearTracks_dxy[max_nearestTrk];
+    double nearTracks_3D_ip[max_nearestTrk];
+    double nearTracks_3D_sip[max_nearestTrk];
+    double nearTracks_2D_ip[max_nearestTrk];
+    double nearTracks_2D_sip[max_nearestTrk];
+    double nearTracks_PCAdist[max_nearestTrk];
+    double nearTracks_PCAdsig[max_nearestTrk];      
+    double nearTracks_PCAonSeed_x[max_nearestTrk];
+    double nearTracks_PCAonSeed_y[max_nearestTrk];
+    double nearTracks_PCAonSeed_z[max_nearestTrk];      
+    double nearTracks_PCAonSeed_xerr[max_nearestTrk];
+    double nearTracks_PCAonSeed_yerr[max_nearestTrk];
+    double nearTracks_PCAonSeed_zerr[max_nearestTrk];      
+    double nearTracks_PCAonTrack_x[max_nearestTrk];
+    double nearTracks_PCAonTrack_y[max_nearestTrk];
+    double nearTracks_PCAonTrack_z[max_nearestTrk];      
+    double nearTracks_PCAonTrack_xerr[max_nearestTrk];
+    double nearTracks_PCAonTrack_yerr[max_nearestTrk];
+    double nearTracks_PCAonTrack_zerr[max_nearestTrk]; 
+    double nearTracks_dotprodTrack[max_nearestTrk];
+    double nearTracks_dotprodSeed[max_nearestTrk];
+    double nearTracks_dotprodTrackSeed2D[max_nearestTrk];
+    double nearTracks_dotprodTrackSeed3D[max_nearestTrk];
+    double nearTracks_dotprodTrackSeedVectors2D[max_nearestTrk];
+    double nearTracks_dotprodTrackSeedVectors3D[max_nearestTrk];      
+    double nearTracks_PCAonSeed_pvd[max_nearestTrk];
+    double nearTracks_PCAonTrack_pvd[max_nearestTrk];
+    double nearTracks_PCAjetAxis_dist[max_nearestTrk];
+    double nearTracks_PCAjetMomenta_dotprod[max_nearestTrk];
+    double nearTracks_PCAjetDirs_DEta[max_nearestTrk];
+    double nearTracks_PCAjetDirs_DPhi[max_nearestTrk];
+    
+    
+    // IVF cut parameters (HARDCODED?? OR CONFIGURABLE IN PYTHON CONFIG)
+    float min3DIPValue=0.005;
+    float min3DIPSignificance=1.2;
+    int max3DIPValue=9999.;
+    int max3DIPSignificance=9999.;
+    
+
+    //tokens to be defined from main analyzer
+    edm::EDGetTokenT<edm::View<pat::PackedCandidate> > CandidateToken;
+
+    //helper:
+    edm::Handle<edm::View<pat::PackedCandidate> > tracks;
+    
+    // builder    
+    edm::ESHandle<TransientTrackBuilder> builder;
+    
+    // temporary containers
+    trackVars2 myTrack;
+    std::vector<trackVars2> nearTracks; 
+    std::multimap<double,std::pair<const reco::TransientTrack*,const std::vector<trackVars2> > > SortedSeedsMap;
+
+
+};
+
+
+
+#endif /* DEEPNTUPLES_DEEPNTUPLIZER_INTERFACE_NTUPLE_DEEPVERTEX_H_ */

--- a/DeepNtuplizer/interface/trackVars2.h
+++ b/DeepNtuplizer/interface/trackVars2.h
@@ -1,0 +1,195 @@
+#ifndef trackVars2_h
+#define trackVars2_h
+
+
+
+class trackVars2 {
+      public:
+    double pt, eta, phi, dz, dxy,  dist, dsig;
+    double mass, t3Dip, t3Dsip, t2Dip, t2Dsip;
+//     double t3DipSigned, t3DsipSigned, t2DipSigned, t2DsipSigned;
+    double PCA_sx, PCA_sy, PCA_sz, PCA_sxerr, PCA_syerr, PCA_szerr;
+    double PCA_tx, PCA_ty, PCA_tz, PCA_txerr, PCA_tyerr, PCA_tzerr;
+    double dotprodTrack, dotprodSeed;
+    double dotprodTrackSeed2D, dotprodTrackSeed3D;
+    double dotprodTrackSeedVectors2D, dotprodTrackSeedVectors3D;
+    double seedPCA_pv, trackPCA_pv;
+    double seedMass;
+    
+    
+//     double PCA_J;
+    double PCA_JetAxis_distance, PCAPair_Jet_dotprod, PCAAxis_JetAxis_DEta, PCAAxis_JetAxis_DPhi; 
+    
+    int index, seed_index;
+    
+    void set_values (double, double, double, double,  double, double, double,
+    double, double, double, double,  double, double,
+    double, double, double, double,  double, double,
+    double, double
+    );
+    
+    void set_signedIPs(double, double, double, double);
+    
+    void set_vars (double, double, double, double,
+    double, double, double, double, double
+    );
+    
+    void set_index ( int );
+    void set_SeedIndex(int);
+    void set_distances ( double, double );
+    
+     void set_JetAxisVars(double, double, double, double);
+     void setSeedMass(double);
+
+};
+
+inline void trackVars2::setSeedMass(double sm){
+    seedMass=sm;
+};
+
+inline void trackVars2::set_values (double pt2, double eta2, double phi2, double dz2, double dxy2, double distaaa, double dsig2,
+double PCA_sx2, double PCA_sy2, double PCA_sz2, double PCA_sxerr2, double PCA_syerr2, double PCA_szerr2, 
+double PCA_tx2, double PCA_ty2, double PCA_tz2, double PCA_txerr2, double PCA_tyerr2, double PCA_tzerr2,
+double dotprodTrack2, double dotprodSeed2) {
+
+    pt=pt2;
+    eta=eta2;
+    phi=phi2; 
+    dz=dz2; 
+    dxy=dxy2; 
+    dist=distaaa;
+    dsig=dsig2;
+    PCA_sx=PCA_sx2;
+    PCA_sy=PCA_sy2;
+    PCA_sz=PCA_sz2; 
+    PCA_sxerr=PCA_sxerr2;
+    PCA_syerr=PCA_syerr2;
+    PCA_szerr=PCA_szerr2;
+    PCA_tx=PCA_tx2;
+    PCA_ty=PCA_ty2;
+    PCA_tz=PCA_tz2; 
+    PCA_txerr=PCA_txerr2;
+    PCA_tyerr=PCA_tyerr2;
+    PCA_tzerr=PCA_tzerr2;
+    dotprodTrack=dotprodTrack2;
+    dotprodSeed=dotprodSeed2;
+    
+//    std::cout << "filling   "<< pt << " " << eta << " " << phi << " " << dz << " " << dxy << " " << dist << " " << dsig << " " << std::endl;
+//    std::cout << "filling   "<< PCA_sx << " " << PCA_sy << " " << PCA_sz << " " << PCA_tx << " " << PCA_ty << " " << PCA_tz << " "  << std::endl;
+//    std::cout << "filling   "<< PCA_sxerr << " " << PCA_syerr << " " << PCA_szerr << " " << PCA_txerr << " " << PCA_tyerr << " " << PCA_tzerr << " "  << std::endl;
+//        std::cout << "filling " << dotprodTrack << "  " << dotprodSeed << std::endl;
+}
+
+inline void trackVars2::set_vars ( double m, double t2dip, double t2dsip, double t3dip, double t3dsip, double t2dTS, double t3dTS, double t2dTSV, double t3dTSV){
+mass=m;
+t3Dip=t3dip;
+t3Dsip=t3dsip;
+t2Dip=t2dip;
+t2Dsip=t2dsip;
+dotprodTrackSeed2D=t2dTS;
+dotprodTrackSeed3D=t3dTS;
+dotprodTrackSeedVectors2D=t2dTSV;
+dotprodTrackSeedVectors3D=t3dTSV;
+
+//  std::cout << "filling  myTrack "<< std::endl;
+
+
+}
+
+// inline void trackVars2::set_signedIPs ( double a, double b, double c, double d){
+// t3DipSigned=c;
+// t3DsipSigned=d;
+// t2DipSigned=a;
+// t2DsipSigned=b;
+// }
+
+
+inline void trackVars2::set_index ( int a){
+index=a;
+}
+
+inline void trackVars2::set_SeedIndex ( int a){
+seed_index=a;
+}
+
+
+inline void trackVars2::set_distances ( double a, double b){
+seedPCA_pv=a;
+trackPCA_pv=b;
+}
+
+
+inline void trackVars2::set_JetAxisVars(double jadist, double dotprod, double d_eta, double d_phi){
+    
+//     std::cout<<one<<std::endl;
+//     PCA_J=one;
+    
+    PCA_JetAxis_distance=jadist;
+    PCAPair_Jet_dotprod=dotprod;
+    PCAAxis_JetAxis_DEta=d_eta;
+    PCAAxis_JetAxis_DPhi=d_phi; 
+}
+
+struct sortfunction2
+{
+    inline bool operator() (const trackVars2& struct1, const trackVars2& struct2)
+    {
+        return (struct1.dist < struct2.dist);
+    }
+};
+
+
+class trackGenMatch2 {
+      public:
+    double chi_square;
+    int numberOfDaughters;
+    int MomFlav;
+    int BChain;
+    int GenIndex;
+    int Status;
+    
+    void set_chi ( double );
+    void set_numberOfDaughters ( int );
+    void set_MomFlav ( int );
+    void set_BChain ( int );
+    void set_GenIndex ( int );
+    void set_Status ( int );
+};
+
+
+inline void trackGenMatch2::set_chi ( double a){
+chi_square=a;
+}
+
+inline void trackGenMatch2::set_numberOfDaughters ( int a){
+numberOfDaughters=a;
+}
+
+inline void trackGenMatch2::set_MomFlav ( int a){
+MomFlav=a;
+}
+
+inline void trackGenMatch2::set_BChain ( int a){
+BChain=a;
+}
+
+inline void trackGenMatch2::set_GenIndex ( int a){
+GenIndex=a;
+}
+
+inline void trackGenMatch2::set_Status ( int a){
+Status=a;
+}
+
+
+
+
+struct sortgen2
+{
+    inline bool operator() (const trackGenMatch2& struct1, const trackGenMatch2& struct2)
+    {
+        return (struct1.chi_square < struct2.chi_square);
+    }
+};
+
+#endif

--- a/DeepNtuplizer/plugins/DeepNtuplizer.cc
+++ b/DeepNtuplizer/plugins/DeepNtuplizer.cc
@@ -12,6 +12,7 @@
 #include "../interface/ntuple_pfCands.h"
 #include "../interface/ntuple_bTagVars.h"
 #include "../interface/ntuple_FatJetInfo.h"
+#include "../interface/ntuple_DeepVertex.h"
 
 //ROOT includes
 #include "TTree.h"
@@ -127,6 +128,11 @@ DeepNtuplizer::DeepNtuplizer(const edm::ParameterSet& iConfig):
                     iConfig.getParameter<edm::InputTag>("LooseSVs")));
     //removed LooseIVF module
     //addModule(svmodule_LooseIVF);
+    
+    // DeepVertex info
+    ntuple_DeepVertex* deepvertexmodule=new ntuple_DeepVertex(jetR);
+    deepvertexmodule->setCandidatesToken(consumes<edm::View<pat::PackedCandidate> >(iConfig.getParameter<edm::InputTag>("candidates")));
+    addModule(deepvertexmodule);
 
     ntuple_JetInfo* jetinfo=new ntuple_JetInfo();
     jetinfo->setQglToken(consumes<edm::ValueMap<float>>(edm::InputTag(t_qgtagger, "qgLikelihood")));

--- a/DeepNtuplizer/python/DeepNtuplizer_cfi.py
+++ b/DeepNtuplizer/python/DeepNtuplizer_cfi.py
@@ -25,4 +25,5 @@ deepntuplizer = cms.EDAnalyzer('DeepNtuplizer',
 		                tagInfoFName = cms.string('pfBoostedDoubleSVAK8'),
                                 bDiscriminators = cms.vstring(),
                                 qgtagger        = cms.string("QGTagger"),
+                                candidates      = cms.InputTag("packedPFCandidates")
                                 )

--- a/DeepNtuplizer/src/ntuple_DeepVertex.cc
+++ b/DeepNtuplizer/src/ntuple_DeepVertex.cc
@@ -155,13 +155,13 @@ bool ntuple_DeepVertex::fillBranches(const pat::Jet & jet, const size_t& jetidx,
         //is the track in the jet cone?
         float angular_distance=std::sqrt(std::pow(jet.eta()-it->track().eta(),2) + std::pow(jet.phi()-it->track().phi(),2) );
         if (angular_distance>jet_radius) { continue; }
-        
+
         // is it a seed track?
         std::pair<bool,Measurement1D> ip = IPTools::absoluteImpactParameter3D(*it, pv);        
         std::pair<bool,Measurement1D> ip2d = IPTools::absoluteTransverseImpactParameter(*it, pv);
-		std::pair<double, Measurement1D> jet_dist =IPTools::jetTrackDistance(*it, direction, pv);                   
+        std::pair<double, Measurement1D> jet_dist =IPTools::jetTrackDistance(*it, direction, pv);                   
         TrajectoryStateOnSurface closest = IPTools::closestApproachToJet(it->impactPointState(),pv, direction,it->field());
-		float length=999;
+        float length=999;
         if (closest.isValid()) length=(closest.globalPosition() - pvp).mag();
         
         // shouldn't it be like this, including the minimal 3DIP cuts? more conform with IVF! https://github.com/cms-sw/cmssw/blob/09c3fce6626f70fd04223e7dacebf0b485f73f54/RecoVertex/AdaptiveVertexFinder/src/TracksClusteringFromDisplacedSeed.cc#L96 
@@ -251,10 +251,7 @@ bool ntuple_DeepVertex::fillBranches(const pat::Jet & jet, const size_t& jetidx,
     unsigned int neartracks_max_counter=0;
     for(std::multimap<double,std::pair<const reco::TransientTrack*,const std::vector<trackVars2> > >::const_iterator im = SortedSeedsMap.begin(); im != SortedSeedsMap.end(); im++){
         
-        if(seeds_max_counter>=10) {
-            //n_seeds = 10;
-            break;
-        }
+        if(seeds_max_counter>=10) break;
         
         std::pair<bool,Measurement1D> ipSigned = IPTools::signedImpactParameter3D(*im->second.first,direction, pv);        
         std::pair<bool,Measurement1D> ip2dSigned = IPTools::signedTransverseImpactParameter(*im->second.first,direction, pv);  
@@ -294,7 +291,7 @@ bool ntuple_DeepVertex::fillBranches(const pat::Jet & jet, const size_t& jetidx,
 
             if((neartracks_max_counter+i)>=200) break;
             
-			nearTracks_pt[neartracks_max_counter+i]=im->second.second.at(i).pt;
+            nearTracks_pt[neartracks_max_counter+i]=im->second.second.at(i).pt;
             nearTracks_eta[neartracks_max_counter+i]=im->second.second.at(i).eta;
             nearTracks_phi[neartracks_max_counter+i]=im->second.second.at(i).phi;
             nearTracks_dz[neartracks_max_counter+i]=im->second.second.at(i).dz;

--- a/DeepNtuplizer/src/ntuple_DeepVertex.cc
+++ b/DeepNtuplizer/src/ntuple_DeepVertex.cc
@@ -29,82 +29,85 @@ void ntuple_DeepVertex::getInput(const edm::ParameterSet& iConfig){
 
 void ntuple_DeepVertex::initBranches(TTree* tree){
     
-    addBranch(tree,"n_seeds",&n_seeds, "n_seeds/I");
+    addBranch(tree,"n_seeds",&n_seeds, "n_seeds/i");
+    addBranch(tree,"nSeeds",&nSeeds, "nSeeds/f");
 
-    addBranch(tree,"seed_pt",&seed_pt, "seed_pt[n_seeds]/D");
-    addBranch(tree,"seed_eta",&seed_eta, "seed_eta[n_seeds]/D");
-    addBranch(tree,"seed_phi",&seed_phi, "seed_phi[n_seeds]/D");
-    addBranch(tree,"seed_mass",&seed_mass, "seed_mass[n_seeds]/D");
+    addBranch(tree,"seed_pt",&seed_pt, "seed_pt[n_seeds]/f");
+    addBranch(tree,"seed_eta",&seed_eta, "seed_eta[n_seeds]/f");
+    addBranch(tree,"seed_phi",&seed_phi, "seed_phi[n_seeds]/f");
+    addBranch(tree,"seed_mass",&seed_mass, "seed_mass[n_seeds]/f");
     
-    addBranch(tree,"seed_dz", &seed_dz, "seed_dz[n_seeds]/D");
-    addBranch(tree,"seed_dxy", &seed_dxy, "seed_dxy[n_seeds]/D");
-    addBranch(tree,"seed_3D_ip", &seed_3D_ip, "seed_3D_ip[n_seeds]/D");
-    addBranch(tree,"seed_3D_sip", &seed_3D_sip, "seed_3D_sip[n_seeds]/D");
-    addBranch(tree,"seed_2D_ip", &seed_2D_ip, "seed_2D_ip[n_seeds]/D");
-    addBranch(tree,"seed_2D_sip", &seed_2D_sip, "seed_2D_sip[n_seeds]/D");
+    addBranch(tree,"seed_dz", &seed_dz, "seed_dz[n_seeds]/f");
+    addBranch(tree,"seed_dxy", &seed_dxy, "seed_dxy[n_seeds]/f");
+    addBranch(tree,"seed_3D_ip", &seed_3D_ip, "seed_3D_ip[n_seeds]/f");
+    addBranch(tree,"seed_3D_sip", &seed_3D_sip, "seed_3D_sip[n_seeds]/f");
+    addBranch(tree,"seed_2D_ip", &seed_2D_ip, "seed_2D_ip[n_seeds]/f");
+    addBranch(tree,"seed_2D_sip", &seed_2D_sip, "seed_2D_sip[n_seeds]/f");
     
-    addBranch(tree,"seed_3D_signedIp", &seed_3D_signedIp, "seed_3D_signedIp[n_seeds]/D");
-    addBranch(tree,"seed_3D_signedSip", &seed_3D_signedSip, "seed_3D_signedSip[n_seeds]/D");
-    addBranch(tree,"seed_2D_signedIp", &seed_2D_signedIp, "seed_2D_signedIp[n_seeds]/D");
-    addBranch(tree,"seed_2D_signedSip", &seed_2D_signedSip, "seed_2D_signedSip[n_seeds]/D");
+    addBranch(tree,"seed_3D_signedIp", &seed_3D_signedIp, "seed_3D_signedIp[n_seeds]/f");
+    addBranch(tree,"seed_3D_signedSip", &seed_3D_signedSip, "seed_3D_signedSip[n_seeds]/f");
+    addBranch(tree,"seed_2D_signedIp", &seed_2D_signedIp, "seed_2D_signedIp[n_seeds]/f");
+    addBranch(tree,"seed_2D_signedSip", &seed_2D_signedSip, "seed_2D_signedSip[n_seeds]/f");
     
-    addBranch(tree,"seed_chi2reduced",&seed_chi2reduced, "seed_chi2reduced[n_seeds]/D");
-    addBranch(tree,"seed_nPixelHits",&seed_nPixelHits, "seed_nPixelHits[n_seeds]/D");
-    addBranch(tree,"seed_nHits",&seed_nHits, "seed_nHits[n_seeds]/D");
-    addBranch(tree,"seed_jetAxisDistance",&seed_jetAxisDistance, "seed_jetAxisDistance[n_seeds]/D");
-    addBranch(tree,"seed_jetAxisDlength",&seed_jetAxisDlength, "seed_jetAxisDlength[n_seeds]/D");
+    addBranch(tree,"seed_chi2reduced",&seed_chi2reduced, "seed_chi2reduced[n_seeds]/f");
+    addBranch(tree,"seed_nPixelHits",&seed_nPixelHits, "seed_nPixelHits[n_seeds]/f");
+    addBranch(tree,"seed_nHits",&seed_nHits, "seed_nHits[n_seeds]/f");
+    addBranch(tree,"seed_jetAxisDistance",&seed_jetAxisDistance, "seed_jetAxisDistance[n_seeds]/f");
+    addBranch(tree,"seed_jetAxisDlength",&seed_jetAxisDlength, "seed_jetAxisDlength[n_seeds]/f");
     
-    addBranch(tree,"seed_nNearTracks",&seed_nNearTracks, "seed_nNearTracks[n_seeds]/I");
+    addBranch(tree,"seed_n_NearTracks",&seed_n_NearTracks, "seed_n_NearTracks[n_seeds]/i");
+    addBranch(tree,"seed_nNearTracks",&seed_nNearTracks, "seed_nNearTracks[n_seeds]/f");
     
     
     
     // near Tracks
     
-    addBranch(tree,"n_NearTracksTotal",&n_NearTracksTotal, "n_NearTracksTotal/I");
+    addBranch(tree,"n_NearTracksTotal",&n_NearTracksTotal, "n_NearTracksTotal/i");
+    addBranch(tree,"nNearTracksTotal",&nNearTracksTotal, "nNearTracksTotal/f");
     
-    addBranch(tree,"nearTracks_pt", &nearTracks_pt, "nearTracks_pt[n_NearTracksTotal]/D");
-    addBranch(tree,"nearTracks_eta", &nearTracks_eta, "nearTracks_eta[n_NearTracksTotal]/D");
-    addBranch(tree,"nearTracks_phi", &nearTracks_phi, "nearTracks_phi[n_NearTracksTotal]/D");
-    addBranch(tree,"nearTracks_mass", &nearTracks_mass, "nearTracks_mass[n_NearTracksTotal]/D");
-    addBranch(tree,"nearTracks_dz", &nearTracks_dz, "nearTracks_dz[n_NearTracksTotal]/D");
-    addBranch(tree,"nearTracks_dxy", &nearTracks_dxy, "nearTracks_dxy[n_NearTracksTotal]/D");
-    addBranch(tree,"nearTracks_3D_ip", &nearTracks_3D_ip, "nearTracks_3D_ip[n_NearTracksTotal]/D");
-    addBranch(tree,"nearTracks_3D_sip", &nearTracks_3D_sip, "nearTracks_3D_sip[n_NearTracksTotal]/D");
-    addBranch(tree,"nearTracks_2D_ip", &nearTracks_2D_ip, "nearTracks_2D_ip[n_NearTracksTotal]/D");
-    addBranch(tree,"nearTracks_2D_sip", &nearTracks_2D_sip, "nearTracks_2D_sip[n_NearTracksTotal]/D");
+    addBranch(tree,"nearTracks_pt", &nearTracks_pt, "nearTracks_pt[n_NearTracksTotal]/f");
+    addBranch(tree,"nearTracks_eta", &nearTracks_eta, "nearTracks_eta[n_NearTracksTotal]/f");
+    addBranch(tree,"nearTracks_phi", &nearTracks_phi, "nearTracks_phi[n_NearTracksTotal]/f");
+    addBranch(tree,"nearTracks_mass", &nearTracks_mass, "nearTracks_mass[n_NearTracksTotal]/f");
+    addBranch(tree,"nearTracks_dz", &nearTracks_dz, "nearTracks_dz[n_NearTracksTotal]/f");
+    addBranch(tree,"nearTracks_dxy", &nearTracks_dxy, "nearTracks_dxy[n_NearTracksTotal]/f");
+    addBranch(tree,"nearTracks_3D_ip", &nearTracks_3D_ip, "nearTracks_3D_ip[n_NearTracksTotal]/f");
+    addBranch(tree,"nearTracks_3D_sip", &nearTracks_3D_sip, "nearTracks_3D_sip[n_NearTracksTotal]/f");
+    addBranch(tree,"nearTracks_2D_ip", &nearTracks_2D_ip, "nearTracks_2D_ip[n_NearTracksTotal]/f");
+    addBranch(tree,"nearTracks_2D_sip", &nearTracks_2D_sip, "nearTracks_2D_sip[n_NearTracksTotal]/f");
 
-    addBranch(tree,"nearTracks_PCAdist", &nearTracks_PCAdist, "nearTracks_PCAdist[n_NearTracksTotal]/D");
-    addBranch(tree,"nearTracks_PCAdsig", &nearTracks_PCAdsig, "nearTracks_PCAdsig[n_NearTracksTotal]/D");
+    addBranch(tree,"nearTracks_PCAdist", &nearTracks_PCAdist, "nearTracks_PCAdist[n_NearTracksTotal]/f");
+    addBranch(tree,"nearTracks_PCAdsig", &nearTracks_PCAdsig, "nearTracks_PCAdsig[n_NearTracksTotal]/f");
     
-    addBranch(tree,"nearTracks_PCAonSeed_x", &nearTracks_PCAonSeed_x, "nearTracks_PCAonSeed_x[n_NearTracksTotal]/D");
-    addBranch(tree,"nearTracks_PCAonSeed_y", &nearTracks_PCAonSeed_y, "nearTracks_PCAonSeed_y[n_NearTracksTotal]/D");
-    addBranch(tree,"nearTracks_PCAonSeed_z", &nearTracks_PCAonSeed_z, "nearTracks_PCAonSeed_z[n_NearTracksTotal]/D");
+    addBranch(tree,"nearTracks_PCAonSeed_x", &nearTracks_PCAonSeed_x, "nearTracks_PCAonSeed_x[n_NearTracksTotal]/f");
+    addBranch(tree,"nearTracks_PCAonSeed_y", &nearTracks_PCAonSeed_y, "nearTracks_PCAonSeed_y[n_NearTracksTotal]/f");
+    addBranch(tree,"nearTracks_PCAonSeed_z", &nearTracks_PCAonSeed_z, "nearTracks_PCAonSeed_z[n_NearTracksTotal]/f");
 
-    addBranch(tree,"nearTracks_PCAonSeed_xerr", &nearTracks_PCAonSeed_xerr, "nearTracks_PCAonSeed_xerr[n_NearTracksTotal]/D");
-    addBranch(tree,"nearTracks_PCAonSeed_yerr", &nearTracks_PCAonSeed_yerr, "nearTracks_PCAonSeed_yerr[n_NearTracksTotal]/D");
-    addBranch(tree,"nearTracks_PCAonSeed_zerr", &nearTracks_PCAonSeed_zerr, "nearTracks_PCAonSeed_zerr[n_NearTracksTotal]/D");
+    addBranch(tree,"nearTracks_PCAonSeed_xerr", &nearTracks_PCAonSeed_xerr, "nearTracks_PCAonSeed_xerr[n_NearTracksTotal]/f");
+    addBranch(tree,"nearTracks_PCAonSeed_yerr", &nearTracks_PCAonSeed_yerr, "nearTracks_PCAonSeed_yerr[n_NearTracksTotal]/f");
+    addBranch(tree,"nearTracks_PCAonSeed_zerr", &nearTracks_PCAonSeed_zerr, "nearTracks_PCAonSeed_zerr[n_NearTracksTotal]/f");
 
-    addBranch(tree,"nearTracks_PCAonTrack_x", &nearTracks_PCAonTrack_x, "nearTracks_PCAonTrack_x[n_NearTracksTotal]/D");
-    addBranch(tree,"nearTracks_PCAonTrack_y", &nearTracks_PCAonTrack_y, "nearTracks_PCAonTrack_y[n_NearTracksTotal]/D");
-    addBranch(tree,"nearTracks_PCAonTrack_z", &nearTracks_PCAonTrack_z, "nearTracks_PCAonTrack_z[n_NearTracksTotal]/D");
+    addBranch(tree,"nearTracks_PCAonTrack_x", &nearTracks_PCAonTrack_x, "nearTracks_PCAonTrack_x[n_NearTracksTotal]/f");
+    addBranch(tree,"nearTracks_PCAonTrack_y", &nearTracks_PCAonTrack_y, "nearTracks_PCAonTrack_y[n_NearTracksTotal]/f");
+    addBranch(tree,"nearTracks_PCAonTrack_z", &nearTracks_PCAonTrack_z, "nearTracks_PCAonTrack_z[n_NearTracksTotal]/f");
 
-    addBranch(tree,"nearTracks_PCAonTrack_xerr", &nearTracks_PCAonTrack_xerr, "nearTracks_PCAonTrack_xerr[n_NearTracksTotal]/D");
-    addBranch(tree,"nearTracks_PCAonTrack_yerr", &nearTracks_PCAonTrack_yerr, "nearTracks_PCAonTrack_yerr[n_NearTracksTotal]/D");
-    addBranch(tree,"nearTracks_PCAonTrack_zerr", &nearTracks_PCAonTrack_zerr, "nearTracks_PCAonTrack_zerr[n_NearTracksTotal]/D"); 
+    addBranch(tree,"nearTracks_PCAonTrack_xerr", &nearTracks_PCAonTrack_xerr, "nearTracks_PCAonTrack_xerr[n_NearTracksTotal]/f");
+    addBranch(tree,"nearTracks_PCAonTrack_yerr", &nearTracks_PCAonTrack_yerr, "nearTracks_PCAonTrack_yerr[n_NearTracksTotal]/f");
+    addBranch(tree,"nearTracks_PCAonTrack_zerr", &nearTracks_PCAonTrack_zerr, "nearTracks_PCAonTrack_zerr[n_NearTracksTotal]/f"); 
 
-    addBranch(tree,"nearTracks_dotprodTrack", &nearTracks_dotprodTrack, "nearTracks_dotprodTrack[n_NearTracksTotal]/D");
-    addBranch(tree,"nearTracks_dotprodSeed", &nearTracks_dotprodSeed, "nearTracks_dotprodSeed[n_NearTracksTotal]/D");
-    addBranch(tree,"nearTracks_dotprodTrackSeed2D", &nearTracks_dotprodTrackSeed2D, "nearTracks_dotprodTrackSeed2D[n_NearTracksTotal]/D");
-    addBranch(tree,"nearTracks_dotprodTrackSeed3D", &nearTracks_dotprodTrackSeed3D, "nearTracks_dotprodTrackSeed3D[n_NearTracksTotal]/D");
-    addBranch(tree,"nearTracks_dotprodTrackSeedVectors2D", &nearTracks_dotprodTrackSeedVectors2D, "nearTracks_dotprodTrackSeedVectors2D[n_NearTracksTotal]/D");
-    addBranch(tree,"nearTracks_dotprodTrackSeedVectors3D", &nearTracks_dotprodTrackSeedVectors3D, "nearTracks_dotprodTrackSeedVectors3D[n_NearTracksTotal]/D");
+    addBranch(tree,"nearTracks_dotprodTrack", &nearTracks_dotprodTrack, "nearTracks_dotprodTrack[n_NearTracksTotal]/f");
+    addBranch(tree,"nearTracks_dotprodSeed", &nearTracks_dotprodSeed, "nearTracks_dotprodSeed[n_NearTracksTotal]/f");
+    addBranch(tree,"nearTracks_dotprodTrackSeed2D", &nearTracks_dotprodTrackSeed2D, "nearTracks_dotprodTrackSeed2D[n_NearTracksTotal]/f");
+    addBranch(tree,"nearTracks_dotprodTrackSeed3D", &nearTracks_dotprodTrackSeed3D, "nearTracks_dotprodTrackSeed3D[n_NearTracksTotal]/f");
+    addBranch(tree,"nearTracks_dotprodTrackSeedVectors2D", &nearTracks_dotprodTrackSeedVectors2D, "nearTracks_dotprodTrackSeedVectors2D[n_NearTracksTotal]/f");
+    addBranch(tree,"nearTracks_dotprodTrackSeedVectors3D", &nearTracks_dotprodTrackSeedVectors3D, "nearTracks_dotprodTrackSeedVectors3D[n_NearTracksTotal]/f");
     
-    addBranch(tree,"nearTracks_PCAonSeed_pvd", &nearTracks_PCAonSeed_pvd, "nearTracks_PCAonSeed_pvd[n_NearTracksTotal]/D");
-    addBranch(tree,"nearTracks_PCAonTrack_pvd", &nearTracks_PCAonTrack_pvd, "nearTracks_PCAonTrack_pvd[n_NearTracksTotal]/D");
-    addBranch(tree,"nearTracks_PCAjetAxis_dist",&nearTracks_PCAjetAxis_dist,"nearTracks_PCAjetAxis_dist[n_NearTracksTotal]/D");
-    addBranch(tree,"nearTracks_PCAjetMomenta_dotprod",&nearTracks_PCAjetMomenta_dotprod,"nearTracks_PCAjetMomenta_dotprod[n_NearTracksTotal]/D");
-    addBranch(tree,"nearTracks_PCAjetDirs_DEta",&nearTracks_PCAjetDirs_DEta,"nearTracks_PCAjetDirs_DEta[n_NearTracksTotal]/D");
-    addBranch(tree,"nearTracks_PCAjetDirs_DPhi",&nearTracks_PCAjetDirs_DPhi,"nearTracks_PCAjetDirs_DPhi[n_NearTracksTotal]/D");
+    addBranch(tree,"nearTracks_PCAonSeed_pvd", &nearTracks_PCAonSeed_pvd, "nearTracks_PCAonSeed_pvd[n_NearTracksTotal]/f");
+    addBranch(tree,"nearTracks_PCAonTrack_pvd", &nearTracks_PCAonTrack_pvd, "nearTracks_PCAonTrack_pvd[n_NearTracksTotal]/f");
+    addBranch(tree,"nearTracks_PCAjetAxis_dist",&nearTracks_PCAjetAxis_dist,"nearTracks_PCAjetAxis_dist[n_NearTracksTotal]/f");
+    addBranch(tree,"nearTracks_PCAjetMomenta_dotprod",&nearTracks_PCAjetMomenta_dotprod,"nearTracks_PCAjetMomenta_dotprod[n_NearTracksTotal]/f");
+    addBranch(tree,"nearTracks_PCAjetDirs_DEta",&nearTracks_PCAjetDirs_DEta,"nearTracks_PCAjetDirs_DEta[n_NearTracksTotal]/f");
+    addBranch(tree,"nearTracks_PCAjetDirs_DPhi",&nearTracks_PCAjetDirs_DPhi,"nearTracks_PCAjetDirs_DPhi[n_NearTracksTotal]/f");
 
 
 }
@@ -283,7 +286,7 @@ bool ntuple_DeepVertex::fillBranches(const pat::Jet & jet, const size_t& jetidx,
         if (closest.isValid()) seed_jetAxisDlength[seeds_max_counter]=(closest.globalPosition() - pvp).mag(); 
         else seed_jetAxisDlength[seeds_max_counter]= -99;
         
-        
+        seed_n_NearTracks[seeds_max_counter]=im->second.second.size();
         seed_nNearTracks[seeds_max_counter]=im->second.second.size();
         
         // FILL NEAREAST VARIABLES
@@ -337,8 +340,10 @@ bool ntuple_DeepVertex::fillBranches(const pat::Jet & jet, const size_t& jetidx,
         neartracks_max_counter += im->second.second.size();
         seeds_max_counter++; 
     }
-    n_NearTracksTotal=neartracks_max_counter;
+    n_NearTracksTotal = neartracks_max_counter;
+    nNearTracksTotal = neartracks_max_counter;
     n_seeds = seeds_max_counter;
+    nSeeds = seeds_max_counter;
     
     SortedSeedsMap.clear();
     nearTracks.clear();

--- a/DeepNtuplizer/src/ntuple_DeepVertex.cc
+++ b/DeepNtuplizer/src/ntuple_DeepVertex.cc
@@ -1,0 +1,349 @@
+/*
+ * ntuple_DeepVertex.cc
+ *
+ *  Created on: 23 June 2017
+ *      Author: Seth Moortgat
+ */
+
+
+#include "../interface/ntuple_DeepVertex.h"
+
+#include "DataFormats/GeometrySurface/interface/Line.h"
+
+#include "TrackingTools/Records/interface/TransientTrackRecord.h"
+#include "TrackingTools/IPTools/interface/IPTools.h"
+#include "TrackingTools/PatternTools/interface/TwoTrackMinimumDistance.h"
+
+
+
+
+
+ntuple_DeepVertex::ntuple_DeepVertex(double jetR):ntuple_content(jetR){
+}
+ntuple_DeepVertex::~ntuple_DeepVertex(){}
+
+
+void ntuple_DeepVertex::getInput(const edm::ParameterSet& iConfig){
+
+}
+
+void ntuple_DeepVertex::initBranches(TTree* tree){
+    
+    addBranch(tree,"n_seeds",&n_seeds, "n_seeds/I");
+
+    addBranch(tree,"seed_pt",&seed_pt, "seed_pt[n_seeds]/D");
+    addBranch(tree,"seed_eta",&seed_eta, "seed_eta[n_seeds]/D");
+    addBranch(tree,"seed_phi",&seed_phi, "seed_phi[n_seeds]/D");
+    addBranch(tree,"seed_mass",&seed_mass, "seed_mass[n_seeds]/D");
+    
+    addBranch(tree,"seed_dz", &seed_dz, "seed_dz[n_seeds]/D");
+    addBranch(tree,"seed_dxy", &seed_dxy, "seed_dxy[n_seeds]/D");
+    addBranch(tree,"seed_3D_ip", &seed_3D_ip, "seed_3D_ip[n_seeds]/D");
+    addBranch(tree,"seed_3D_sip", &seed_3D_sip, "seed_3D_sip[n_seeds]/D");
+    addBranch(tree,"seed_2D_ip", &seed_2D_ip, "seed_2D_ip[n_seeds]/D");
+    addBranch(tree,"seed_2D_sip", &seed_2D_sip, "seed_2D_sip[n_seeds]/D");
+    
+    addBranch(tree,"seed_3D_signedIp", &seed_3D_signedIp, "seed_3D_signedIp[n_seeds]/D");
+    addBranch(tree,"seed_3D_signedSip", &seed_3D_signedSip, "seed_3D_signedSip[n_seeds]/D");
+    addBranch(tree,"seed_2D_signedIp", &seed_2D_signedIp, "seed_2D_signedIp[n_seeds]/D");
+    addBranch(tree,"seed_2D_signedSip", &seed_2D_signedSip, "seed_2D_signedSip[n_seeds]/D");
+    
+    addBranch(tree,"seed_chi2reduced",&seed_chi2reduced, "seed_chi2reduced[n_seeds]/D");
+    addBranch(tree,"seed_nPixelHits",&seed_nPixelHits, "seed_nPixelHits[n_seeds]/D");
+    addBranch(tree,"seed_nHits",&seed_nHits, "seed_nHits[n_seeds]/D");
+    addBranch(tree,"seed_jetAxisDistance",&seed_jetAxisDistance, "seed_jetAxisDistance[n_seeds]/D");
+    addBranch(tree,"seed_jetAxisDlength",&seed_jetAxisDlength, "seed_jetAxisDlength[n_seeds]/D");
+    
+    addBranch(tree,"seed_nNearTracks",&seed_nNearTracks, "seed_nNearTracks[n_seeds]/I");
+    
+    
+    
+    // near Tracks
+    
+    addBranch(tree,"n_NearTracksTotal",&n_NearTracksTotal, "n_NearTracksTotal/I");
+    
+    addBranch(tree,"nearTracks_pt", &nearTracks_pt, "nearTracks_pt[n_NearTracksTotal]/D");
+    addBranch(tree,"nearTracks_eta", &nearTracks_eta, "nearTracks_eta[n_NearTracksTotal]/D");
+    addBranch(tree,"nearTracks_phi", &nearTracks_phi, "nearTracks_phi[n_NearTracksTotal]/D");
+    addBranch(tree,"nearTracks_mass", &nearTracks_mass, "nearTracks_mass[n_NearTracksTotal]/D");
+    addBranch(tree,"nearTracks_dz", &nearTracks_dz, "nearTracks_dz[n_NearTracksTotal]/D");
+    addBranch(tree,"nearTracks_dxy", &nearTracks_dxy, "nearTracks_dxy[n_NearTracksTotal]/D");
+    addBranch(tree,"nearTracks_3D_ip", &nearTracks_3D_ip, "nearTracks_3D_ip[n_NearTracksTotal]/D");
+    addBranch(tree,"nearTracks_3D_sip", &nearTracks_3D_sip, "nearTracks_3D_sip[n_NearTracksTotal]/D");
+    addBranch(tree,"nearTracks_2D_ip", &nearTracks_2D_ip, "nearTracks_2D_ip[n_NearTracksTotal]/D");
+    addBranch(tree,"nearTracks_2D_sip", &nearTracks_2D_sip, "nearTracks_2D_sip[n_NearTracksTotal]/D");
+
+    addBranch(tree,"nearTracks_PCAdist", &nearTracks_PCAdist, "nearTracks_PCAdist[n_NearTracksTotal]/D");
+    addBranch(tree,"nearTracks_PCAdsig", &nearTracks_PCAdsig, "nearTracks_PCAdsig[n_NearTracksTotal]/D");
+    
+    addBranch(tree,"nearTracks_PCAonSeed_x", &nearTracks_PCAonSeed_x, "nearTracks_PCAonSeed_x[n_NearTracksTotal]/D");
+    addBranch(tree,"nearTracks_PCAonSeed_y", &nearTracks_PCAonSeed_y, "nearTracks_PCAonSeed_y[n_NearTracksTotal]/D");
+    addBranch(tree,"nearTracks_PCAonSeed_z", &nearTracks_PCAonSeed_z, "nearTracks_PCAonSeed_z[n_NearTracksTotal]/D");
+
+    addBranch(tree,"nearTracks_PCAonSeed_xerr", &nearTracks_PCAonSeed_xerr, "nearTracks_PCAonSeed_xerr[n_NearTracksTotal]/D");
+    addBranch(tree,"nearTracks_PCAonSeed_yerr", &nearTracks_PCAonSeed_yerr, "nearTracks_PCAonSeed_yerr[n_NearTracksTotal]/D");
+    addBranch(tree,"nearTracks_PCAonSeed_zerr", &nearTracks_PCAonSeed_zerr, "nearTracks_PCAonSeed_zerr[n_NearTracksTotal]/D");
+
+    addBranch(tree,"nearTracks_PCAonTrack_x", &nearTracks_PCAonTrack_x, "nearTracks_PCAonTrack_x[n_NearTracksTotal]/D");
+    addBranch(tree,"nearTracks_PCAonTrack_y", &nearTracks_PCAonTrack_y, "nearTracks_PCAonTrack_y[n_NearTracksTotal]/D");
+    addBranch(tree,"nearTracks_PCAonTrack_z", &nearTracks_PCAonTrack_z, "nearTracks_PCAonTrack_z[n_NearTracksTotal]/D");
+
+    addBranch(tree,"nearTracks_PCAonTrack_xerr", &nearTracks_PCAonTrack_xerr, "nearTracks_PCAonTrack_xerr[n_NearTracksTotal]/D");
+    addBranch(tree,"nearTracks_PCAonTrack_yerr", &nearTracks_PCAonTrack_yerr, "nearTracks_PCAonTrack_yerr[n_NearTracksTotal]/D");
+    addBranch(tree,"nearTracks_PCAonTrack_zerr", &nearTracks_PCAonTrack_zerr, "nearTracks_PCAonTrack_zerr[n_NearTracksTotal]/D"); 
+
+    addBranch(tree,"nearTracks_dotprodTrack", &nearTracks_dotprodTrack, "nearTracks_dotprodTrack[n_NearTracksTotal]/D");
+    addBranch(tree,"nearTracks_dotprodSeed", &nearTracks_dotprodSeed, "nearTracks_dotprodSeed[n_NearTracksTotal]/D");
+    addBranch(tree,"nearTracks_dotprodTrackSeed2D", &nearTracks_dotprodTrackSeed2D, "nearTracks_dotprodTrackSeed2D[n_NearTracksTotal]/D");
+    addBranch(tree,"nearTracks_dotprodTrackSeed3D", &nearTracks_dotprodTrackSeed3D, "nearTracks_dotprodTrackSeed3D[n_NearTracksTotal]/D");
+    addBranch(tree,"nearTracks_dotprodTrackSeedVectors2D", &nearTracks_dotprodTrackSeedVectors2D, "nearTracks_dotprodTrackSeedVectors2D[n_NearTracksTotal]/D");
+    addBranch(tree,"nearTracks_dotprodTrackSeedVectors3D", &nearTracks_dotprodTrackSeedVectors3D, "nearTracks_dotprodTrackSeedVectors3D[n_NearTracksTotal]/D");
+    
+    addBranch(tree,"nearTracks_PCAonSeed_pvd", &nearTracks_PCAonSeed_pvd, "nearTracks_PCAonSeed_pvd[n_NearTracksTotal]/D");
+    addBranch(tree,"nearTracks_PCAonTrack_pvd", &nearTracks_PCAonTrack_pvd, "nearTracks_PCAonTrack_pvd[n_NearTracksTotal]/D");
+    addBranch(tree,"nearTracks_PCAjetAxis_dist",&nearTracks_PCAjetAxis_dist,"nearTracks_PCAjetAxis_dist[n_NearTracksTotal]/D");
+    addBranch(tree,"nearTracks_PCAjetMomenta_dotprod",&nearTracks_PCAjetMomenta_dotprod,"nearTracks_PCAjetMomenta_dotprod[n_NearTracksTotal]/D");
+    addBranch(tree,"nearTracks_PCAjetDirs_DEta",&nearTracks_PCAjetDirs_DEta,"nearTracks_PCAjetDirs_DEta[n_NearTracksTotal]/D");
+    addBranch(tree,"nearTracks_PCAjetDirs_DPhi",&nearTracks_PCAjetDirs_DPhi,"nearTracks_PCAjetDirs_DPhi[n_NearTracksTotal]/D");
+
+
+}
+
+
+void ntuple_DeepVertex::readEvent(const edm::Event& iEvent){
+
+    iEvent.getByToken(CandidateToken, tracks);
+
+}
+
+
+void ntuple_DeepVertex::readSetup(const edm::EventSetup& iSetup){
+
+    iSetup.get<TransientTrackRecord>().get("TransientTrackBuilder", builder);
+
+}
+
+
+
+
+bool ntuple_DeepVertex::fillBranches(const pat::Jet & jet, const size_t& jetidx, const  edm::View<pat::Jet> * coll){
+
+    // pv info
+    const reco::Vertex &pv = vertices()->at(0);
+    GlobalPoint pvp(pv.x(),pv.y(),pv.z());
+
+    
+    std::vector<reco::TransientTrack> selectedTracks;
+    std::vector<float> masses;
+    
+    
+   for(size_t k = 0; k<tracks->size(); ++k) {
+        if((*tracks)[k].bestTrack() != 0 &&  (*tracks)[k].pt()>0.5 && std::fabs(pvp.z()-builder->build(tracks->ptrAt(k)).track().vz())<0.5) {
+            selectedTracks.push_back(builder->build(tracks->ptrAt(k)));
+            masses.push_back(tracks->ptrAt(k)->mass());
+        }
+    }
+    
+    double jet_radius = jetR();
+    GlobalVector direction(jet.px(), jet.py(), jet.pz());
+    
+    for(std::vector<reco::TransientTrack>::const_iterator it = selectedTracks.begin(); it != selectedTracks.end(); it++){
+
+        //is the track in the jet cone?
+        float angular_distance=std::sqrt(std::pow(jet.eta()-it->track().eta(),2) + std::pow(jet.phi()-it->track().phi(),2) );
+        if (angular_distance>jet_radius) { continue; }
+        
+        // is it a seed track?
+        std::pair<bool,Measurement1D> ip = IPTools::absoluteImpactParameter3D(*it, pv);        
+        std::pair<bool,Measurement1D> ip2d = IPTools::absoluteTransverseImpactParameter(*it, pv);
+		std::pair<double, Measurement1D> jet_dist =IPTools::jetTrackDistance(*it, direction, pv);                   
+        TrajectoryStateOnSurface closest = IPTools::closestApproachToJet(it->impactPointState(),pv, direction,it->field());
+		float length=999;
+        if (closest.isValid()) length=(closest.globalPosition() - pvp).mag();
+        
+        // shouldn't it be like this, including the minimal 3DIP cuts? more conform with IVF! https://github.com/cms-sw/cmssw/blob/09c3fce6626f70fd04223e7dacebf0b485f73f54/RecoVertex/AdaptiveVertexFinder/src/TracksClusteringFromDisplacedSeed.cc#L96 
+        // bool is_seed_candidate = (ip.first && ip.second.value() >= min3DIPValue && ip.second.significance() >= min3DIPSignificance &&
+//             ip.second.value() <= max3DIPValue && ip.second.significance() <= max3DIPSignificance &&
+//             it->track().normalizedChi2()<5. && std::fabs(it->track().dxy(pv.position())) < 2 &&
+//             std::fabs(it->track().dz(pv.position())) < 17  && jet_dist.second.value()<0.07 && length<5. );
+
+        // this is what is in the DeepVertex code: https://github.com/leonardogiannini/Analyzer/blob/master/plugins/AnalyzerSignedIP_MINIAOD_wArr.cc#L886-L889
+        bool is_seed_candidate = (ip.first && ip.second.value() >= 0.0 && ip.second.significance() >= 1.0 &&
+            ip.second.value() <= max3DIPValue && ip.second.significance() <= max3DIPSignificance &&
+            it->track().normalizedChi2()<5. && std::fabs(it->track().dxy(pv.position())) < 2 &&
+            std::fabs(it->track().dz(pv.position())) < 17  && jet_dist.second.value()<0.07 && length<5. );
+        
+        if (!is_seed_candidate){continue;}
+        
+        std::pair<bool,Measurement1D> ipSigned = IPTools::signedImpactParameter3D(*it,direction, pv); 
+        //n_seeds++;
+        
+        nearTracks.clear();
+        //now that we found a seed, loop over all other tracks and look for neighbours
+        for(std::vector<reco::TransientTrack>::const_iterator tt = selectedTracks.begin();tt!=selectedTracks.end(); ++tt ) {
+            VertexDistance3D distanceComputer;
+            TwoTrackMinimumDistance dist;
+            if(*tt==*it) continue;
+            if(std::fabs(pvp.z()-tt->track().vz())>0.1) continue;
+            if(dist.calculate(tt->impactPointState(),it->impactPointState())) {
+                GlobalPoint ttPoint          = dist.points().first;
+                GlobalError ttPointErr       = tt->impactPointState().cartesianError().position();
+                GlobalPoint seedPosition     = dist.points().second;
+                GlobalError seedPositionErr  = it->impactPointState().cartesianError().position();
+                Measurement1D m = distanceComputer.distance(VertexState(seedPosition,seedPositionErr), VertexState(ttPoint, ttPointErr));
+                GlobalPoint cp(dist.crossingPoint()); 
+                
+                GlobalVector PairMomentum(it->track().px()+tt->track().px(), it->track().py()+tt->track().py(), it->track().pz()+tt->track().pz());
+                GlobalVector  PCA_pv(cp-pvp);
+
+                float PCAseedFromPV =  (dist.points().second-pvp).mag();
+                float PCAtrackFromPV =  (dist.points().first-pvp).mag();               
+                float distance = dist.distance();
+
+                GlobalVector trackDir2D(tt->impactPointState().globalDirection().x(),tt->impactPointState().globalDirection().y(),0.); 
+                GlobalVector seedDir2D(it->impactPointState().globalDirection().x(),it->impactPointState().globalDirection().y(),0.); 
+                GlobalVector trackPCADir2D(dist.points().first.x()-pvp.x(),dist.points().first.y()-pvp.y(),0.); 
+                GlobalVector seedPCADir2D(dist.points().second.x()-pvp.x(),dist.points().second.y()-pvp.y(),0.); 
+                
+                float dotprodTrack = (dist.points().first-pvp).unit().dot(tt->impactPointState().globalDirection().unit());
+                float dotprodSeed = (dist.points().second-pvp).unit().dot(it->impactPointState().globalDirection().unit());                    
+                float dotprodTrackSeed2D = trackDir2D.unit().dot(seedDir2D.unit());
+                float dotprodTrackSeed3D = it->impactPointState().globalDirection().unit().dot(tt->impactPointState().globalDirection().unit());
+                float dotprodTrackSeed2DV = trackPCADir2D.unit().dot(seedPCADir2D.unit());
+                float dotprodTrackSeed3DV = (dist.points().second-pvp).unit().dot((dist.points().first-pvp).unit());
+
+                std::pair<bool,Measurement1D> t_ip = IPTools::absoluteImpactParameter3D(*tt,pv);        
+                std::pair<bool,Measurement1D> t_ip2d = IPTools::absoluteTransverseImpactParameter(*tt,pv);
+
+                myTrack.set_values(tt->track().pt(), tt->track().eta(), tt->track().phi(),  tt->track().dz(pv.position()), tt->track().dxy(pv.position()), distance,  m.significance(), seedPosition.x(), seedPosition.y(), seedPosition.z(), seedPositionErr.cxx(), seedPositionErr.cyy(), seedPositionErr.czz(),  ttPoint.x(),  ttPoint.y(),  ttPoint.z(),  ttPointErr.cxx(),  ttPointErr.cyy(),  ttPointErr.czz(), dotprodTrack, dotprodSeed );
+                myTrack.set_index(-1);
+                myTrack.set_distances(PCAseedFromPV, PCAtrackFromPV);
+                myTrack.set_vars(masses[tt-selectedTracks.begin()],t_ip2d.second.value() , t_ip2d.second.significance(), t_ip.second.value() , t_ip.second.significance(), dotprodTrackSeed2D, dotprodTrackSeed3D, dotprodTrackSeed2DV, dotprodTrackSeed3DV ); 
+                
+                Line::PositionType pos(pvp);
+                Line::DirectionType dir(direction);
+                Line::DirectionType pairMomentumDir(PairMomentum);
+                Line jetLine(pos,dir);   
+                Line PCAMomentumLine(cp,pairMomentumDir);
+                float PCA_JetAxis_dist=jetLine.distance(cp).mag();
+                float dotprodMomenta=PairMomentum.unit().dot(direction.unit());
+                float dEta=std::fabs(PCA_pv.eta()-jet.eta());
+                float dPhi=std::fabs(PCA_pv.phi()-jet.phi());
+
+                myTrack.setSeedMass(masses[it-selectedTracks.begin()]);                    
+                myTrack.set_JetAxisVars(PCA_JetAxis_dist,dotprodMomenta,dEta,dPhi);
+                nearTracks.push_back(myTrack);
+            
+            }
+        }            
+         
+        std::sort (nearTracks.begin(), nearTracks.end(), sortfunction2());
+        if (nearTracks.size() > 20){nearTracks.resize(20);}
+        SortedSeedsMap.insert(std::make_pair(-ipSigned.second.significance(), std::make_pair(&(*it), nearTracks)));
+            
+    }
+    
+       
+    unsigned int seeds_max_counter=0;
+    unsigned int neartracks_max_counter=0;
+    for(std::multimap<double,std::pair<const reco::TransientTrack*,const std::vector<trackVars2> > >::const_iterator im = SortedSeedsMap.begin(); im != SortedSeedsMap.end(); im++){
+        
+        if(seeds_max_counter>=10) {
+            //n_seeds = 10;
+            break;
+        }
+        
+        std::pair<bool,Measurement1D> ipSigned = IPTools::signedImpactParameter3D(*im->second.first,direction, pv);        
+        std::pair<bool,Measurement1D> ip2dSigned = IPTools::signedTransverseImpactParameter(*im->second.first,direction, pv);  
+        std::pair<bool,Measurement1D> ip = IPTools::absoluteImpactParameter3D(*im->second.first, pv);        
+        std::pair<bool,Measurement1D> ip2d = IPTools::absoluteTransverseImpactParameter(*im->second.first, pv);	
+        
+        seed_pt[seeds_max_counter]=im->second.first->track().pt();
+        seed_eta[seeds_max_counter]=im->second.first->track().eta();
+        seed_phi[seeds_max_counter]=im->second.first->track().phi();
+        seed_mass[seeds_max_counter]=im->second.second.at(0).seedMass;
+        seed_dz[seeds_max_counter]=im->second.first->track().dz(pv.position());
+        seed_dxy[seeds_max_counter]=im->second.first->track().dxy(pv.position());
+        seed_3D_ip[seeds_max_counter]=ip.second.value();
+        seed_3D_sip[seeds_max_counter]=ip.second.significance();
+        seed_2D_ip[seeds_max_counter]=ip2d.second.value();
+        seed_2D_sip[seeds_max_counter]=ip2d.second.significance();
+        seed_3D_signedIp[seeds_max_counter]=ipSigned.second.value();
+        seed_3D_signedSip[seeds_max_counter]=ipSigned.second.significance();
+        seed_2D_signedIp[seeds_max_counter]=ip2dSigned.second.value();
+        seed_2D_signedSip[seeds_max_counter]=ip2dSigned.second.significance();		
+        seed_chi2reduced[seeds_max_counter]=im->second.first->track().normalizedChi2();
+        seed_nPixelHits[seeds_max_counter]=im->second.first->track().hitPattern().numberOfValidPixelHits();
+        seed_nHits[seeds_max_counter]=im->second.first->track().hitPattern().numberOfValidHits();
+
+        std::pair<double, Measurement1D> jet_distance =IPTools::jetTrackDistance(*im->second.first, direction, pv);
+        seed_jetAxisDistance[seeds_max_counter]=std::fabs(jet_distance.second.value());
+
+        TrajectoryStateOnSurface closest = IPTools::closestApproachToJet(im->second.first->impactPointState(),pv, direction,im->second.first->field());
+        if (closest.isValid()) seed_jetAxisDlength[seeds_max_counter]=(closest.globalPosition() - pvp).mag(); 
+        else seed_jetAxisDlength[seeds_max_counter]= -99;
+        
+        
+        seed_nNearTracks[seeds_max_counter]=im->second.second.size();
+        
+        // FILL NEAREAST VARIABLES
+        for(unsigned int i=0; i< im->second.second.size(); i++) {
+
+            if((neartracks_max_counter+i)>=200) break;
+            
+			nearTracks_pt[neartracks_max_counter+i]=im->second.second.at(i).pt;
+            nearTracks_eta[neartracks_max_counter+i]=im->second.second.at(i).eta;
+            nearTracks_phi[neartracks_max_counter+i]=im->second.second.at(i).phi;
+            nearTracks_dz[neartracks_max_counter+i]=im->second.second.at(i).dz;
+            nearTracks_dxy[neartracks_max_counter+i]=im->second.second.at(i).dxy;
+            nearTracks_mass[neartracks_max_counter+i]=im->second.second.at(i).mass;
+            nearTracks_3D_ip[neartracks_max_counter+i]=im->second.second.at(i).t3Dip;
+            nearTracks_3D_sip[neartracks_max_counter+i]=im->second.second.at(i).t3Dsip;
+            nearTracks_2D_ip[neartracks_max_counter+i]=im->second.second.at(i).t2Dip;
+            nearTracks_2D_sip[neartracks_max_counter+i]=im->second.second.at(i).t2Dsip;
+            nearTracks_PCAdist[neartracks_max_counter+i]=im->second.second.at(i).dist;
+            nearTracks_PCAdsig[neartracks_max_counter+i]=im->second.second.at(i).dsig;
+            nearTracks_PCAonSeed_x[neartracks_max_counter+i]=im->second.second.at(i).PCA_sx;
+            nearTracks_PCAonSeed_y[neartracks_max_counter+i]=im->second.second.at(i).PCA_sy;
+            nearTracks_PCAonSeed_z[neartracks_max_counter+i]=im->second.second.at(i).PCA_sz;
+            nearTracks_PCAonSeed_xerr[neartracks_max_counter+i]=im->second.second.at(i).PCA_sxerr;
+            nearTracks_PCAonSeed_yerr[neartracks_max_counter+i]=im->second.second.at(i).PCA_syerr;
+            nearTracks_PCAonSeed_zerr[neartracks_max_counter+i]=im->second.second.at(i).PCA_szerr;
+            nearTracks_PCAonTrack_x[neartracks_max_counter+i]=im->second.second.at(i).PCA_tx;
+            nearTracks_PCAonTrack_y[neartracks_max_counter+i]=im->second.second.at(i).PCA_ty;
+            nearTracks_PCAonTrack_z[neartracks_max_counter+i]=im->second.second.at(i).PCA_tz;
+            nearTracks_PCAonTrack_xerr[neartracks_max_counter+i]=im->second.second.at(i).PCA_txerr;
+            nearTracks_PCAonTrack_yerr[neartracks_max_counter+i]=im->second.second.at(i).PCA_tyerr;
+            nearTracks_PCAonTrack_zerr[neartracks_max_counter+i]=im->second.second.at(i).PCA_tzerr;
+            nearTracks_dotprodTrack[neartracks_max_counter+i]=im->second.second.at(i).dotprodTrack;
+            nearTracks_dotprodSeed[neartracks_max_counter+i]=im->second.second.at(i).dotprodSeed;
+            nearTracks_dotprodTrackSeed2D[neartracks_max_counter+i]=im->second.second.at(i).dotprodTrackSeed2D;
+            nearTracks_dotprodTrackSeed3D[neartracks_max_counter+i]=im->second.second.at(i).dotprodTrackSeed3D;
+            nearTracks_dotprodTrackSeedVectors2D[neartracks_max_counter+i]=im->second.second.at(i).dotprodTrackSeedVectors2D;
+            nearTracks_dotprodTrackSeedVectors3D[neartracks_max_counter+i]=im->second.second.at(i).dotprodTrackSeedVectors3D;
+
+            nearTracks_PCAonSeed_pvd[neartracks_max_counter+i]=im->second.second.at(i).seedPCA_pv;
+            nearTracks_PCAonTrack_pvd[neartracks_max_counter+i]=im->second.second.at(i).trackPCA_pv;
+
+            nearTracks_PCAjetAxis_dist[neartracks_max_counter+i]=im->second.second.at(i).PCA_JetAxis_distance;
+            nearTracks_PCAjetMomenta_dotprod[neartracks_max_counter+i]=im->second.second.at(i).PCAPair_Jet_dotprod;
+
+            nearTracks_PCAjetDirs_DEta[neartracks_max_counter+i]=im->second.second.at(i).PCAAxis_JetAxis_DEta;
+            nearTracks_PCAjetDirs_DPhi[neartracks_max_counter+i]=im->second.second.at(i).PCAAxis_JetAxis_DPhi;
+
+        }
+        
+        // *********
+        neartracks_max_counter += im->second.second.size();
+        seeds_max_counter++; 
+    }
+    n_NearTracksTotal=neartracks_max_counter;
+    n_seeds = seeds_max_counter;
+    
+    SortedSeedsMap.clear();
+    nearTracks.clear();
+    masses.clear();
+
+    return true;
+}
+


### PR DESCRIPTION
included all variables from slide 15 of: https://indico.cern.ch/event/644179/contributions/2615002/attachments/1472156/2278491/BTV_7_6.pdf 

"n_seeds" hold per jet the stored number of seeding tracks. Seeds are stored according to descending "seed_3D_signedSip". A maximum of 10 seeds are stored.

For each seed there is a variable "seed_nNearTracks" that holds the selected number of neighbouring tracks. This is usually equal to the maximum of 20, but in some rare cases this is smaller. 

The neighbouring track properties are stored in a sequential way for different seeds. For example: if there are 2 seeding tracks each with 20 neighbours then the first 20 values in the "nearTracks_" branches are from the first seed and the following 20 are from the second seed. For each seed the neighbouring tracks are sorted according to increasing "nearTracks_PCAdist".

There exists also a variable called "n_NearTracksTotal" that reflects (on a per-jet basis) the total number or stored neighbouring tracks to all seeds in the jet. This is probably redundant but can serve as a cross check.

the IVF selection on seeding tracks is currently slightly loosened to get a bit more seeding tracks.