### PR TITLE
Herwig++ quick fix: override flavor definition with udsg based ID onl…

### DIFF
--- a/DeepNtuplizer/interface/helpers.h
+++ b/DeepNtuplizer/interface/helpers.h
@@ -10,7 +10,7 @@
 
 namespace deep_ntuples {
     enum JetFlavor {UNDEFINED, G, UD, S, C, GCC, CC, B, GBB, BB, LeptonicB, LeptonicB_C};
-    JetFlavor jet_flavour(const pat::Jet& jet, std::vector<reco::GenParticle> gToBB, std::vector<reco::GenParticle> gToCC, std::vector<reco::GenParticle> neutrinosLepB, std::vector<reco::GenParticle> neutrinosLepB_C, bool usePhysForLightAndUndefined=false);
+    JetFlavor jet_flavour(const pat::Jet& jet, std::vector<reco::GenParticle> gToBB, std::vector<reco::GenParticle> gToCC, std::vector<reco::GenParticle> neutrinosLepB, std::vector<reco::GenParticle> neutrinosLepB_C, std::vector<reco::GenParticle> hpp_udsgpartons, bool usePhysForLightAndUndefined=false);
     std::vector<std::size_t> jet_muonsIds(const pat::Jet& jet, const std::vector<pat::Muon>& event_muons); 
     std::vector<std::size_t> jet_electronsIds(const pat::Jet& jet, const std::vector<pat::Electron>& event_electrons); 
 }

--- a/DeepNtuplizer/interface/ntuple_JetInfo.h
+++ b/DeepNtuplizer/interface/ntuple_JetInfo.h
@@ -110,6 +110,7 @@ public:
     std::vector <reco::GenParticle> neutrinosLepB;
     std::vector <reco::GenParticle> neutrinosLepB_C;
 
+    std::vector<reco::GenParticle> hpp_udsgpartons;
     std::vector<reco::GenParticle> gToBB;
     std::vector<reco::GenParticle> gToCC;
 

--- a/DeepNtuplizer/src/helpers.cc
+++ b/DeepNtuplizer/src/helpers.cc
@@ -23,7 +23,29 @@ std::vector<std::size_t> jet_electronsIds(const pat::Jet& jet, const std::vector
 
 JetFlavor jet_flavour(const pat::Jet& jet, std::vector<reco::GenParticle> gToBB, std::vector<reco::GenParticle> gToCC,
         std::vector<reco::GenParticle> neutrinosLepB, std::vector<reco::GenParticle> neutrinosLepB_C, 
+        std::vector<reco::GenParticle> hpp_udsgpartons,
         bool usePhysForLightAndUndefined) { 
+
+    //temporary quick and dirty fix - define flavor in herwig samples (i.e. with status 11 genpartons) only by these and not fiddle aroudn with the logic of the rest
+  //    std::cout << "dhortcut flavor definition" << std::endl;
+    //    std::cout << "hpp_udsgpartons.size()" << hpp_udsgpartons.size() << std::endl;
+    if (hpp_udsgpartons.size()>0){
+      double drtemp = 0.4;      
+      JetFlavor flavtemp = JetFlavor::UNDEFINED;
+      for (reco::GenParticle p : hpp_udsgpartons) {
+        double dr(reco::deltaR(jet, p));
+        //        std::cout << "dr " << dr << " pdgid " << std::abs(p.pdgId()) << std::endl; 
+        if (dr < 0.4 && dr < drtemp){
+          int id(std::abs(p.pdgId()));
+          if(id == 21) flavtemp = JetFlavor::G;
+          else if(id == 3) flavtemp = JetFlavor::S;
+          else if(id == 2 || id ==1) flavtemp = JetFlavor::UD;
+          else flavtemp = JetFlavor::UNDEFINED;
+        }
+      }
+      return flavtemp;
+    }
+
     int hflav = abs(jet.hadronFlavour());
     int pflav = abs(jet.partonFlavour());
     int physflav = 0;

--- a/DeepNtuplizer/src/ntuple_JetInfo.cc
+++ b/DeepNtuplizer/src/ntuple_JetInfo.cc
@@ -187,6 +187,11 @@ void ntuple_JetInfo::readEvent(const edm::Event& iEvent){
           }
         }
 
+        if ( (id==1 || id == 2 || id==3 || id == 21) && (status = 11 )){
+          //std::cout << "found Herwig parton for q/g id " << id << std::endl;
+          hpp_udsgpartons.push_back(gen);
+        }
+
     }
     //technically a branch fill but per event, therefore here
 }
@@ -268,7 +273,7 @@ bool ntuple_JetInfo::fillBranches(const pat::Jet & jet, const size_t& jetidx, co
     }
 
     //// Note that jets with gluon->bb (cc) and x->bb (cc) are in the same categories
-    switch(deep_ntuples::jet_flavour(jet, gToBB, gToCC, neutrinosLepB, neutrinosLepB_C)) {
+    switch(deep_ntuples::jet_flavour(jet, gToBB, gToCC, neutrinosLepB, neutrinosLepB_C,hpp_udsgpartons)) {
     case deep_ntuples::JetFlavor::B:  isB_=1; break;
     case deep_ntuples::JetFlavor::LeptonicB: isLeptonicB_=1; break;
     case deep_ntuples::JetFlavor::LeptonicB_C: isLeptonicB_C_=1; break;
@@ -286,7 +291,7 @@ bool ntuple_JetInfo::fillBranches(const pat::Jet & jet, const size_t& jetidx, co
     //truth labeling with fallback to physics definition for light/gluon/undefined of standard flavor definition
     //// Note that jets with gluon->bb (cc) and x->bb (cc) are in the same categories
     isPhysB_=0; isPhysBB_=0; isPhysGBB_=0; isPhysC_=0; isPhysCC_=0; isPhysGCC_=0; isPhysUD_=0; isPhysS_=0; isPhysG_=0, isPhysLeptonicB_=0, isPhysLeptonicB_C_=0, isPhysUndefined_=0;
-    switch(deep_ntuples::jet_flavour(jet, gToBB, gToCC, neutrinosLepB, neutrinosLepB_C, true)) {
+    switch(deep_ntuples::jet_flavour(jet, gToBB, gToCC, neutrinosLepB, neutrinosLepB_C, hpp_udsgpartons, true)) {
     case deep_ntuples::JetFlavor::UD: isPhysUD_=1; break;
     case deep_ntuples::JetFlavor::S:  isPhysS_=1; break;
     case deep_ntuples::JetFlavor::B:  isPhysB_=1; break;


### PR DESCRIPTION
…y (status 11 for Herwig++) and ignore any other definition to focus on q/g cross check with Herwig++