### PR TITLE
PYTHIA status 23 flavor definition only (overrides everything else)

### DIFF
--- a/DeepNtuplizer/src/helpers.cc
+++ b/DeepNtuplizer/src/helpers.cc
@@ -27,7 +27,8 @@ JetFlavor jet_flavour(const pat::Jet& jet, std::vector<reco::GenParticle> gToBB,
         bool usePhysForLightAndUndefined) { 
 
     //temporary quick and dirty fix - define flavor in herwig samples (i.e. with status 11 genpartons) only by these and not fiddle aroudn with the logic of the rest
-  //    std::cout << "dhortcut flavor definition" << std::endl;
+    // NOW ALSO FILL hpp_udsgpartons with PYTHIA status 23 partons, so OVERRIDING ALL FLAVOR DEFINITION SUBLETIES BELOW THE FOLLOWING COUPLE OF LINES
+    //    std::cout << "dhortcut flavor definition" << std::endl;
     //    std::cout << "hpp_udsgpartons.size()" << hpp_udsgpartons.size() << std::endl;
     if (hpp_udsgpartons.size()>0){
       double drtemp = 0.4;      

--- a/DeepNtuplizer/src/ntuple_JetInfo.cc
+++ b/DeepNtuplizer/src/ntuple_JetInfo.cc
@@ -193,6 +193,16 @@ void ntuple_JetInfo::readEvent(const edm::Event& iEvent){
         }
 
     }
+    for (const reco::Candidate &genC : *genParticlesHandle) { // treat flavor definition for PYTHIA the same way as for Herwig++, i.e. follow definition in
+      // https://indico.cern.ch/event/587258/contributions/2366496/attachments/1368896/2075082/QGL_JMAR_9Nov.pdf#search=Giorgia%20Rauco%20AND%20cerntaxonomy%3A%22Indico%2FExperiments%2FCMS%20meetings%2FPH%20%2D%20Physics%2FJets%20and%20missing%20energy%20%28JetMET%29%22
+        const reco::GenParticle &gen = static_cast< const reco::GenParticle &>(genC);
+        int id(std::abs(gen.pdgId())); 
+        int status(gen.status());
+        if (hpp_udsgpartons.size()>0 && hpp_udsgpartons.back().status()==11) throw std::runtime_error("ntuple_JetInfo::readEvent: already filled with herwig status 11 partons - that shouldn't happen for PYTHIA?!"); 
+        if ( (id==1 || id == 2 || id==3 || id == 21) && (status = 23 )){
+          hpp_udsgpartons.push_back(gen);
+        }
+    }
     //technically a branch fill but per event, therefore here
 }
 

--- a/DeepNtuplizer/src/ntuple_JetInfo.cc
+++ b/DeepNtuplizer/src/ntuple_JetInfo.cc
@@ -198,8 +198,8 @@ void ntuple_JetInfo::readEvent(const edm::Event& iEvent){
         const reco::GenParticle &gen = static_cast< const reco::GenParticle &>(genC);
         int id(std::abs(gen.pdgId())); 
         int status(gen.status());
-        if (hpp_udsgpartons.size()>0 && hpp_udsgpartons.back().status()==11) throw std::runtime_error("ntuple_JetInfo::readEvent: already filled with herwig status 11 partons - that shouldn't happen for PYTHIA?!"); 
         if ( (id==1 || id == 2 || id==3 || id == 21) && (status = 23 )){
+          if (hpp_udsgpartons.size()>0 && hpp_udsgpartons.back().status()==11) throw std::runtime_error("ntuple_JetInfo::readEvent: already filled with herwig status 11 partons - that shouldn't happen for PYTHIA?!"); 
           hpp_udsgpartons.push_back(gen);
         }
     }


### PR DESCRIPTION
use PYTHIA status 23 partons the same way as for Herwig to completely override any flavor definition we had before