### PR TITLE
Merge samples 

### DIFF
--- a/DeepNtuplizer/scripts/mergeSamples.py
+++ b/DeepNtuplizer/scripts/mergeSamples.py
@@ -27,6 +27,8 @@ if not os.path.isdir(args.outdir):
         allins+=' '+l
         
     syscall('createMergeList '+str(args.nsamples)+' '+args.outdir+' '+allins)
+else :
+    raise IOError('The output directory', args.outdir, 'does already exist! Stop merging process')
     
     
 #read number of jobs

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ When the file lists are created, the part used for training of the ttbar and QCD
 mergeSamples <no of jets per file> <output dir> <file lists 1> <file lists 2> <file lists 3> ...
 ```
 Note that there should be at least two separate file lists. One for ttbar and one for QCD. 
-Otherwise the jets are not randomised properly.
+Otherwise the jets are not randomized properly.
 
 For example:
 ```

--- a/README.md
+++ b/README.md
@@ -105,9 +105,13 @@ When the file lists are created, the part used for training of the ttbar and QCD
 ```
 mergeSamples <no of jets per file> <output dir> <file lists 1> <file lists 2> <file lists 3> ...
 ```
+Note that there should be at least two separate file lists. One for ttbar and one for QCD. 
+Otherwise the jets are not randomised properly.
+
 For example:
 ```
-mergeSamples 400000 merged ntuple_*/train_val_samples.txt
+mergeSamples 400000 merged ntuple_ttbar*/train_val_samples.txt ntuple_qcd*/train_val_samples.txt
+
 ```
 This will take a significant amount of time - likely more than the ntuple production itself. It is therefore recommended to run the command within 'screen'.
 


### PR DESCRIPTION
If the output directory already exists the merging crashes with an error message that 
"outpath/nentries" does not exists. Which doesn't help a lot. 
Though to my understanding the problem is rather that the outpath did already exist.
Therefore I think one should catch this before and raise an Error if the outpath does exist.