### PR TITLE
added a try catch block for genDecay calculation

### DIFF
--- a/DeepNtuplizer/src/ntuple_JetInfo.cc
+++ b/DeepNtuplizer/src/ntuple_JetInfo.cc
@@ -389,40 +389,45 @@ bool ntuple_JetInfo::fillBranches(const pat::Jet & jet, const size_t& jetidx, co
 
     genDecay_ = -1.;
 
-//    reco::GenParticleRefVector Bhadrons_in_jet = jet.jetFlavourInfo().getbHadrons();
-//
-//    if (Bhadrons_in_jet.size() > 0){ 
-//
-//        for (unsigned int idx=0; idx<Bhadron_.size(); ++idx){
-//
-//            reco::GenParticle bhad = Bhadron_[idx];
-//
-//            bool bhad_is_in_jet = false;
-//
-//            for (reco::GenParticleRefVector::const_iterator bhad_in_jet = Bhadrons_in_jet.begin(); bhad_in_jet!=Bhadrons_in_jet.end(); ++bhad_in_jet) {
-//
-//                //check if bhad is identical to bhad_in_jet
-//                if ( (*bhad_in_jet)->pt() == bhad.pt() && (*bhad_in_jet)->eta() == bhad.eta()
-//                        && (*bhad_in_jet)->phi() == bhad.phi() && (*bhad_in_jet)->pdgId() == bhad.pdgId())              
-//                    bhad_is_in_jet = true;
-//            }
-//            if (bhad_is_in_jet){
-//
-//                if (Bhadron_daughter_[idx].vx()!=bhad.vx()){
-//                    
-//                    float vx = Bhadron_daughter_[idx].vx() - bhad.vx();
-//                    float vy = Bhadron_daughter_[idx].vy() - bhad.vy();
-//
-//                    float dxy = sqrt(vx*vx+vy*vy);
-//                    if (dxy > genDecay_)
-//                        genDecay_= dxy;
-//                }
-//                else if (genDecay_ < 0) 
-//                    genDecay_ = -0.1;
-//            }
-//        }
-//    }
-//
+    try {
+        reco::GenParticleRefVector Bhadrons_in_jet = jet.jetFlavourInfo().getbHadrons();
+
+        if (Bhadrons_in_jet.size() > 0){ 
+
+            for (unsigned int idx=0; idx<Bhadron_.size(); ++idx){
+
+                reco::GenParticle bhad = Bhadron_[idx];
+
+                bool bhad_is_in_jet = false;
+
+                for (reco::GenParticleRefVector::const_iterator bhad_in_jet = Bhadrons_in_jet.begin(); bhad_in_jet!=Bhadrons_in_jet.end(); ++bhad_in_jet) {
+
+                    //check if bhad is identical to bhad_in_jet
+                    if ( (*bhad_in_jet)->pt() == bhad.pt() && (*bhad_in_jet)->eta() == bhad.eta()
+                            && (*bhad_in_jet)->phi() == bhad.phi() && (*bhad_in_jet)->pdgId() == bhad.pdgId())              
+                        bhad_is_in_jet = true;
+                }
+                if (bhad_is_in_jet){
+
+                    if (Bhadron_daughter_[idx].vx()!=bhad.vx()){
+
+                        float vx = Bhadron_daughter_[idx].vx() - bhad.vx();
+                        float vy = Bhadron_daughter_[idx].vy() - bhad.vy();
+
+                        float dxy = sqrt(vx*vx+vy*vy);
+                        if (dxy > genDecay_)
+                            genDecay_= dxy;
+                    }
+                    else if (genDecay_ < 0) 
+                        genDecay_ = -0.1;
+                }
+            }
+        }
+    }
+    catch (const cms::Exception &e){
+        genDecay_ = -1.;
+    }
+
 
 
     //https://twiki.cern.ch/twiki/bin/view/CMS/JetID13TeVRun2016


### PR DESCRIPTION
Addressing issue #50 
Adding a try catch block around the calculation of genDecay, so that the code runs even if genDecay cannot be calculated.

I tested the code with: /eos/cms/store/mc/RunIIFall17MiniAOD/TTToSemiLeptonic_TuneCP5_13TeV-powheg-pythia8/MINIAODSIM/94X_mc2017_realistic_v10-v1/00000/100F19C9-FDF8-E711-AD89-801844DEEF1C.root

and: /eos/cms/store/mc/RunIIFall17MiniAOD/QCD_Pt_50to80_TuneCP5_13TeV_pythia8/MINIAODSIM/94X_mc2017_realistic_v11_ext1-v1/70000/6025D7BF-6732-E811-9F96-FA163EDF22C6.root


and:/eos/cms/store/mc/PhaseIITDRFall17MiniAOD/TT_TuneCUETP8M2T4_14TeV-powheg-pythia8/MINIAODSIM/PU200_93X_upgrade2023_realistic_v2_ext1-v1/30000/F2A8268B-16C7-E711-BA54-0025904C4F52.root
